### PR TITLE
Recompute listing_device_name_length_max on MacOS, too

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -1883,6 +1883,12 @@ GList *tty_search_for_serial_devices(void)
 
         // Add device information to device list
         device_list = g_list_append(device_list, device);
+
+        // Update length of longest device name string
+        if (strlen(device->path) > listing_device_name_length_max)
+        {
+            listing_device_name_length_max = strlen(device->path);
+        }
     }
 
     if (g_list_length(device_list) == 0)


### PR DESCRIPTION
Recompute listing_device_name_length_max so that the width of column 0,
the device name, has the correct number of spaces emitted so the rest of
the columns can be formatted more simply with fixed width printf.
